### PR TITLE
Add version that uses bash + xclip instead of Powershell

### DIFF
--- a/copyTime-no-powershell.lua
+++ b/copyTime-no-powershell.lua
@@ -1,0 +1,23 @@
+require 'mp'
+require 'os'
+
+local function set_clipboard(text)
+    -- Change path to companion script below
+    mp.commandv("run", "/path/to/copyTime-no-powershell.sh", text);
+end
+
+local function copyTime()
+    local time_pos = mp.get_property_number("time-pos")
+    local time_in_seconds = time_pos
+    local time_seg = time_pos % 60
+    time_pos = time_pos - time_seg
+    local time_hours = math.floor(time_pos / 3600)
+    time_pos = time_pos - (time_hours * 3600)
+    local time_minutes = time_pos/60
+    time_seg,time_ms=string.format("%.03f", time_seg):match"([^.]*).(.*)"
+    time = string.format("%02d:%02d:%02d.%s", time_hours, time_minutes, time_seg, time_ms)
+    mp.osd_message(string.format("Copied to Clipboard: %s", time))
+    set_clipboard(time)
+end
+
+mp.add_key_binding("Ctrl+c", "copyTime", copyTime)

--- a/copyTime-no-powershell.lua
+++ b/copyTime-no-powershell.lua
@@ -1,5 +1,4 @@
 require 'mp'
-require 'os'
 
 local function set_clipboard(text)
     -- Change path to companion script below

--- a/copyTime-no-powershell.sh
+++ b/copyTime-no-powershell.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-echo $1 | xclip -selection c
+echo -n $1 | xclip -selection c

--- a/copyTime-no-powershell.sh
+++ b/copyTime-no-powershell.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo $1 | xclip -selection c


### PR DESCRIPTION
I've made some edits to the lua script so that it works on Linux without Powershell.

Another *tiny* thing I changed was reducing the number of digits for the ms part from 9 to 3, as originally, I would see 6 redundant zeros in the output each time.

I’m new to writing scripts for mpv (and in lua), so there very well may be a more efficient way to do this. Feel free to make modifications however you like.

And finally, thank you! This is the only customisable way I’ve found so far that includes milliseconds, which comes very handy.