### PR TITLE
fix for distros with both wayland and x11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Put the script `copyTime.lua` in your scripts folder, usually in:
 To work, the script needs:
 * Windows: `Powershell`.
 * Linux/X11: `xclip`.
-* Linux/Wayland : `xclip` or `wl-clipboard`.
+* Linux/Wayland : `wl-clipboard`.
 * MacOS: `pbcopy` (not tested). 
 
 # Screenshot

--- a/copyTime.lua
+++ b/copyTime.lua
@@ -20,6 +20,14 @@ local function command_exists(cmd)
     local pipe = io.popen("type " .. cmd .. " > /dev/null 2> /dev/null; printf \"$?\"", "r")
     exists = pipe:read() == "0"
     pipe:close()
+
+    -- show error if command not exists
+    if not exists and cmd == "pbcopy" then
+        mp.msg.error(cmd .. " package not found! please install it (MacOS-only).")
+    elseif not exists then
+        mp.msg.error(cmd .. " package not found! please install it.")
+    end
+
     return exists
 end
 
@@ -38,7 +46,6 @@ local function get_clipboard_cmd()
     elseif command_exists("pbcopy") then
         return "pbcopy"
     else
-        mp.msg.error("No supported clipboard command found")
         return false
     end
 end

--- a/copyTime.lua
+++ b/copyTime.lua
@@ -23,10 +23,17 @@ local function command_exists(cmd)
     return exists
 end
 
+local function display_servers(cmd)
+    local pipe = io.popen("echo $XDG_SESSION_TYPE")
+    exists = pipe:read() == cmd
+    pipe:close()
+    return exists
+end
+
 local function get_clipboard_cmd()
-    if command_exists("xclip") then
+    if display_servers("x11") and command_exists("xclip") then
         return "xclip -silent -in -selection clipboard"
-    elseif command_exists("wl-copy") then
+    elseif display_servers("wayland") and command_exists("wl-copy") then
         return "wl-copy"
     elseif command_exists("pbcopy") then
         return "pbcopy"
@@ -40,7 +47,7 @@ local function divmod(a, b)
     return a / b, a % b
 end
 
-local function set_clipboard(text) 
+local function set_clipboard(text)
     if platform == WINDOWS then
         mp.commandv("run", "powershell", "set-clipboard", text)
         return true

--- a/copyTime.lua
+++ b/copyTime.lua
@@ -20,19 +20,13 @@ local function command_exists(cmd)
     local pipe = io.popen("type " .. cmd .. " > /dev/null 2> /dev/null; printf \"$?\"", "r")
     exists = pipe:read() == "0"
     pipe:close()
-
-    -- show error if command not exists
-    if not exists and cmd == "pbcopy" then
-        mp.msg.error(cmd .. " package not found! please install it (MacOS-only).")
-    elseif not exists then
-        mp.msg.error(cmd .. " package not found! please install it.")
-    end
-
     return exists
 end
 
+-- reference for io.popen:
+-- https://pubs.opengroup.org/onlinepubs/009695399/functions/popen.html
 local function display_servers(cmd)
-    local pipe = io.popen("echo $XDG_SESSION_TYPE")
+    local pipe = io.popen("echo $XDG_SESSION_TYPE", "r")
     exists = pipe:read() == cmd
     pipe:close()
     return exists
@@ -46,6 +40,7 @@ local function get_clipboard_cmd()
     elseif command_exists("pbcopy") then
         return "pbcopy"
     else
+        mp.msg.error("No supported clipboard command found")
         return false
     end
 end
@@ -89,4 +84,4 @@ if platform == UNIX then
     clipboard_cmd = get_clipboard_cmd()
 end
 
-mp.add_key_binding("Ctrl+c", "copyTime", copyTime)
+mp.add_key_binding("ALT+x", "copyTime", copyTime)

--- a/copyTime.lua
+++ b/copyTime.lua
@@ -20,6 +20,14 @@ local function command_exists(cmd)
     local pipe = io.popen("type " .. cmd .. " > /dev/null 2> /dev/null; printf \"$?\"", "r")
     exists = pipe:read() == "0"
     pipe:close()
+
+    -- show error if command not exists
+    if not exists and cmd == "pbcopy" then
+        mp.msg.error(cmd .. " package not found! please install it (MacOS-only).")
+    elseif not exists then
+        mp.msg.error(cmd .. " package not found! please install it.")
+    end
+
     return exists
 end
 
@@ -84,4 +92,4 @@ if platform == UNIX then
     clipboard_cmd = get_clipboard_cmd()
 end
 
-mp.add_key_binding("ALT+x", "copyTime", copyTime)
+mp.add_key_binding("Ctrl+c", "copyTime", copyTime)


### PR DESCRIPTION
exception bug fix: now if user has both x11 and wayland on their distro (such as Fedora 36) and has installed both xclip and wl-clipboard the code will work between on both display protocols without the need to edit it.
p.s I has tested xclip on wayland did not work as such fixed the README.md