### PR TITLE
Proper rounding for milliseconds

### DIFF
--- a/copyTime.lua
+++ b/copyTime.lua
@@ -60,7 +60,7 @@ local function copyTime()
     local minutes, remainder = divmod(time_pos, 60)
     local hours, minutes = divmod(minutes, 60)
     local seconds = math.floor(remainder)
-    local milliseconds = math.floor((remainder - seconds) * 1000)
+    local milliseconds = math.floor((remainder - seconds) * 1000 + 0.5)
     local time = string.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds)
     if set_clipboard(time) then
         mp.osd_message(string.format("Copied to Clipboard: %s", time))


### PR DESCRIPTION
I don't know if this works for everyone, but I had the problem that the timestamps where often 1 millisecond too early because you used floor instead of rouding, but maybe this breaks it for other people, I don't know.